### PR TITLE
Fix wait condition when the element is absent

### DIFF
--- a/src/element/getElement.ts
+++ b/src/element/getElement.ts
@@ -17,7 +17,8 @@ export async function getElement(
   }
 
   const element = await context.waitForSelector(selectorOrElement, options);
-  if (element === null) {
+  const isElementHidden = options && options.hidden === true;
+  if (element === null && !isElementHidden) {
     throw new Error(
       `The element by selector ${selectorOrElement} wasn't found.`,
     );

--- a/tests/element/wait/waitToBeNotVisible.spec.ts
+++ b/tests/element/wait/waitToBeNotVisible.spec.ts
@@ -20,4 +20,16 @@ describe('Element Wait: waitToBeNotVisible()', () => {
     startButtonStatus = await isVisible(page, startButtonSelector);
     expect(startButtonStatus).toBeFalsy();
   });
+
+  it('should not throw an exception if the element is not present', async () => {
+    const notPresentSelector = 'some-selector';
+    let exception = null;
+
+    try {
+      await waitToBeNotVisible(page, notPresentSelector, { timeoutMs: 1000 });
+    } catch (e) {
+      exception = e;
+    }
+    expect(exception).toBeNull();
+  });
 });


### PR DESCRIPTION
## Description
- don't throw an exception when using the method `waitToBeNotVisible` and the element is not present in the DOM.