### PR TITLE
Add support of new version of puppeteer-core

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x, 16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,10 @@ dist
 node_modules
 docs
 
+/.idea/.gitignore
+/.idea/bubanai.iml
+/.idea/jsLinters/eslint.xml
+/.idea/jsLibraryMappings.xml
+/.idea/modules.xml
+/.idea/inspectionProfiles/Project_Default.xml
+/.idea/vcs.xml

--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,4 @@ dist
 node_modules
 docs
 
-/.idea/.gitignore
-/.idea/bubanai.iml
-/.idea/jsLinters/eslint.xml
-/.idea/jsLibraryMappings.xml
-/.idea/modules.xml
-/.idea/inspectionProfiles/Project_Default.xml
-/.idea/vcs.xml
+/.idea

--- a/package.json
+++ b/package.json
@@ -39,11 +39,12 @@
   "jest": {
     "preset": "jest-puppeteer"
   },
-  "dependencies": {
-    "puppeteer": "^5.5.0",
-    "puppeteer-core": "^5.5.0"
+  "peerDependencies": {
+    "puppeteer-core": "14.3.0"
   },
   "devDependencies": {
+    "puppeteer": "14.3.0",
+    "puppeteer-core": "14.3.0",
     "@types/expect-puppeteer": "^4.4.5",
     "@types/jest": "^26.0.15",
     "@types/jest-environment-puppeteer": "^4.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bubanai",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "license": "MIT",
   "author": "Wix.com",
   "description": "A testing library to simplify the usage of raw Puppeteer methods",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bubanai",
-  "version": "0.0.17",
+  "version": "0.1.0",
   "license": "MIT",
   "author": "Wix.com",
   "description": "A testing library to simplify the usage of raw Puppeteer methods",

--- a/src/element/actions/type.ts
+++ b/src/element/actions/type.ts
@@ -2,6 +2,7 @@ import { ElementHandle, Frame, Page } from 'puppeteer-core';
 import { TYPE_ACTION_DELAY } from '../../settings';
 import { getElement, SearchElementOptions } from '../getElement';
 import { clearInput } from './clearInput';
+import { click } from './click';
 
 export interface TypeOptions {
   delayMs?: number;
@@ -36,6 +37,7 @@ export async function type(
     selectorOrElement,
     searchElementOptions,
   );
+  await click(context, element);
 
   if (mergedTypeOptions.clearInput) {
     await clearInput(context, element, {}, page);

--- a/src/element/getElement.ts
+++ b/src/element/getElement.ts
@@ -17,8 +17,7 @@ export async function getElement(
   }
 
   const element = await context.waitForSelector(selectorOrElement, options);
-  const isElementHidden = options && options.hidden === true;
-  if (element === null && !isElementHidden) {
+  if (element === null) {
     throw new Error(
       `The element by selector ${selectorOrElement} wasn't found.`,
     );

--- a/src/element/states/isVisible.ts
+++ b/src/element/states/isVisible.ts
@@ -21,7 +21,9 @@ export async function isVisible(
     return false;
   }
 
-  const isBoxVisible = await isBoundingBoxVisible(element);
+  const isBoxVisible = await isBoundingBoxVisible(
+    element as unknown as ElementHandle,
+  );
   const opacity = await getComputedStyle(
     StyleProperty.OPACITY,
     context,

--- a/tests/collection/search/getElementIndexByText.spec.ts
+++ b/tests/collection/search/getElementIndexByText.spec.ts
@@ -1,4 +1,4 @@
-import { getElementIndexByText } from '../../../src/collection/search/getElementIndexByText';
+import { getElementIndexByText } from '../../../src';
 
 describe('Collection Search: getElementIndexByText()', () => {
   const headerSelector = 'tr th';
@@ -13,7 +13,7 @@ describe('Collection Search: getElementIndexByText()', () => {
 
     const searchedIndex = await getElementIndexByText(
       searchText,
-      page,
+      page as never,
       headerSelector,
     );
 
@@ -26,7 +26,7 @@ describe('Collection Search: getElementIndexByText()', () => {
 
     const searchedIndex = await getElementIndexByText(
       searchText,
-      page,
+      page as never,
       headerSelector,
       {},
       true,
@@ -42,8 +42,8 @@ describe('Collection Search: getElementIndexByText()', () => {
 
     const searchedIndex = await getElementIndexByText(
       searchText,
-      page,
-      elements,
+      page as never,
+      elements as never,
     );
 
     expect(searchedIndex).toBe(expectedIndex);

--- a/tests/element/actions/click.spec.ts
+++ b/tests/element/actions/click.spec.ts
@@ -1,4 +1,4 @@
-import { click } from '../../../src/element/actions/click';
+import { click } from '../../../src';
 
 describe('Element Action: click()', () => {
   it('should add element by clicking and delete it', async () => {
@@ -7,8 +7,8 @@ describe('Element Action: click()', () => {
     const addElementSelector = "[onclick = 'addElement()']";
     const deleteElementSelector = "[onclick = 'deleteElement()']";
 
-    await click(page, addElementSelector);
-    await click(page, deleteElementSelector);
+    await click(page as never, addElementSelector);
+    await click(page as never, deleteElementSelector);
 
     expect(await page.$$(deleteElementSelector)).toHaveLength(0);
   });
@@ -17,9 +17,9 @@ describe('Element Action: click()', () => {
     await page.goto('http://the-internet.herokuapp.com/dynamic_controls');
 
     const buttonSelector = '#checkbox-example button';
-    await click(page, buttonSelector);
+    await click(page as never, buttonSelector);
 
-    await expect(click(page, buttonSelector)).rejects.toThrowError(
+    await expect(click(page as never, buttonSelector)).rejects.toThrowError(
       `the element with selector '${buttonSelector}' is disabled.`,
     );
   });

--- a/tests/element/actions/getText.spec.ts
+++ b/tests/element/actions/getText.spec.ts
@@ -1,27 +1,25 @@
-import { getText } from '../../../src/element/actions/getText';
-import { getElement } from '../../../src/element/getElement';
-import { getFrameByName } from '../../../src/frame/search/getFrameByName';
+import { getText, getElement, getFrameByName } from '../../../src';
 
 describe('Element Action: getText()', () => {
   it('should get text using the selector', async () => {
     await page.goto('http://the-internet.herokuapp.com/login');
 
-    const text = await getText(page, 'h2');
+    const text = await getText(page as never, 'h2');
     expect(text).toBe('Login Page');
   });
 
   it('should get text using the element', async () => {
     await page.goto('http://the-internet.herokuapp.com/login');
 
-    const element = await getElement(page, 'h2');
-    const text = await getText(page, element);
+    const element = await getElement(page as never, 'h2');
+    const text = await getText(page as never, element);
     expect(text).toBe('Login Page');
   });
 
   it('should get text using the element inside the frame', async () => {
     await page.goto('http://the-internet.herokuapp.com/nested_frames');
 
-    const frame = await getFrameByName(page, 'frame-middle');
+    const frame = await getFrameByName(page as never, 'frame-middle');
     const element = await getElement(frame, '#content');
     const text = await getText(frame, element);
     expect(text).toBe('MIDDLE');

--- a/tests/element/actions/getValue.spec.ts
+++ b/tests/element/actions/getValue.spec.ts
@@ -1,6 +1,4 @@
-import { getValue } from '../../../src/element/actions/getValue';
-import { click } from '../../../src/element/actions/click';
-import { getElement } from '../../../src/element/getElement';
+import { getValue, click, getElement } from '../../../src';
 
 describe('Element Action: getValue()', () => {
   const sliderSelector = 'input';
@@ -11,23 +9,23 @@ describe('Element Action: getValue()', () => {
   });
 
   it('should get value using the selector', async () => {
-    const value = await getValue(page, sliderSelector);
+    const value = await getValue(page as never, sliderSelector);
     expect(value).toBe(defaultValue);
   });
 
   it('should get value using the element', async () => {
-    const slider = await getElement(page, sliderSelector);
-    const value = await getValue(page, slider);
+    const slider = await getElement(page as never, sliderSelector);
+    const value = await getValue(page as never, slider);
     expect(value).toBe(defaultValue);
   });
 
   it('should return the updated value', async () => {
-    let value = await getValue(page, sliderSelector);
+    let value = await getValue(page as never, sliderSelector);
     expect(value).toBe(defaultValue);
 
-    await click(page, sliderSelector);
+    await click(page as never, sliderSelector);
 
-    value = await getValue(page, sliderSelector);
+    value = await getValue(page as never, sliderSelector);
     expect(value).toBe('2.5');
   });
 });

--- a/tests/element/actions/hover.spec.ts
+++ b/tests/element/actions/hover.spec.ts
@@ -1,5 +1,4 @@
-import { hover } from '../../../src/element/actions/hover';
-import { isVisible } from '../../../src/element/states/isVisible';
+import { hover, isVisible } from '../../../src';
 
 describe('Element Action: hover()', () => {
   beforeAll(async () => {
@@ -10,10 +9,10 @@ describe('Element Action: hover()', () => {
     const imgSelector = '[src="/img/avatar-blank.jpg"]';
     const profileLink = '[href="/users/1"]';
 
-    expect(await isVisible(page, profileLink)).toBeFalsy();
+    expect(await isVisible(page as never, profileLink)).toBeFalsy();
 
-    await hover(page, imgSelector);
+    await hover(page as never, imgSelector);
 
-    expect(await isVisible(page, profileLink)).toBeTruthy();
+    expect(await isVisible(page as never, profileLink)).toBeTruthy();
   });
 });

--- a/tests/element/actions/type.spec.ts
+++ b/tests/element/actions/type.spec.ts
@@ -1,12 +1,9 @@
-import { getText } from '../../../src/element/actions/getText';
-import { getValue } from '../../../src/element/actions/getValue';
-import { type } from '../../../src/element/actions/type';
-import { getFrameByName } from '../../../src/frame/search/getFrameByName';
+import { getText, getValue, type, getFrameByName } from '../../../src';
 
 describe('Element Action: type()', () => {
   it('should type the value to the TinyMCE WYSIWYG Editor', async () => {
     const newTextValue = '42: The answer to life, the universe and everything';
-    const areaSelector = 'body';
+    const areaSelector = '#tinymce > p';
     const frameSelector = 'mce_0_ifr';
 
     await page.goto('http://the-internet.herokuapp.com/tinymce');
@@ -15,11 +12,11 @@ describe('Element Action: type()', () => {
     await type(newTextValue, frame, areaSelector, {}, {}, page);
     const newText = await getText(frame, areaSelector);
     expect(newText).toBe(newTextValue);
-  });
+  }, 15000);
 
   it('should type the value to the TinyMCE WYSIWYG Editor without clearing', async () => {
-    const newTextValue = 'Additional content. ';
-    const areaSelector = 'body';
+    const newTextValue = 'Additional content.';
+    const areaSelector = '#tinymce > p';
     const frameSelector = 'mce_0_ifr';
 
     await page.goto('http://the-internet.herokuapp.com/tinymce');
@@ -36,7 +33,7 @@ describe('Element Action: type()', () => {
       page,
     );
     const newText = await getText(frame, areaSelector);
-    expect(newText).toBe(newTextValue + currentText);
+    expect(newText).toBe(currentText + newTextValue);
   });
 
   it('should type the value to the input', async () => {

--- a/tests/element/actions/type.spec.ts
+++ b/tests/element/actions/type.spec.ts
@@ -7,9 +7,9 @@ describe('Element Action: type()', () => {
     const frameSelector = 'mce_0_ifr';
 
     await page.goto('http://the-internet.herokuapp.com/tinymce');
-    const frame = await getFrameByName(page, frameSelector);
+    const frame = await getFrameByName(page as never, frameSelector);
 
-    await type(newTextValue, frame, areaSelector, {}, {}, page);
+    await type(newTextValue, frame, areaSelector, {}, {}, page as never);
     const newText = await getText(frame, areaSelector);
     expect(newText).toBe(newTextValue);
   }, 15000);
@@ -20,7 +20,7 @@ describe('Element Action: type()', () => {
     const frameSelector = 'mce_0_ifr';
 
     await page.goto('http://the-internet.herokuapp.com/tinymce');
-    const frame = await getFrameByName(page, frameSelector);
+    const frame = await getFrameByName(page as never, frameSelector);
 
     const currentText = await getText(frame, areaSelector);
 
@@ -30,7 +30,7 @@ describe('Element Action: type()', () => {
       areaSelector,
       {},
       { clearInput: false },
-      page,
+      page as never,
     );
     const newText = await getText(frame, areaSelector);
     expect(newText).toBe(currentText + newTextValue);
@@ -42,8 +42,8 @@ describe('Element Action: type()', () => {
 
     await page.goto('http://the-internet.herokuapp.com/inputs');
 
-    await type(newValue, page, inputSelector);
-    const text = await getValue(page, inputSelector);
+    await type(newValue, page as never, inputSelector);
+    const text = await getValue(page as never, inputSelector);
     expect(text).toBe(newValue);
   });
 });

--- a/tests/element/states/isDisabled.spec.ts
+++ b/tests/element/states/isDisabled.spec.ts
@@ -1,4 +1,4 @@
-import { isDisabled } from '../../../src/element/states/isDisabled';
+import { isDisabled } from '../../../src';
 
 describe('Element State: isDisabled()', () => {
   beforeAll(async () => {
@@ -6,12 +6,18 @@ describe('Element State: isDisabled()', () => {
   });
 
   it('should return false if the element is not disabled', async () => {
-    const isDisabledValue = await isDisabled(page, '#checkbox-example button');
+    const isDisabledValue = await isDisabled(
+      page as never,
+      '#checkbox-example button',
+    );
     expect(isDisabledValue).toBeFalsy();
   });
 
   it('should return true if the element is disabled', async () => {
-    const isDisabledValue = await isDisabled(page, '#input-example input');
+    const isDisabledValue = await isDisabled(
+      page as never,
+      '#input-example input',
+    );
     expect(isDisabledValue).toBeTruthy();
   });
 });

--- a/tests/element/states/isVisible.spec.ts
+++ b/tests/element/states/isVisible.spec.ts
@@ -1,24 +1,24 @@
-import { isVisible } from '../../../src/element/states/isVisible';
+import { isVisible } from '../../../src';
 
 describe('Element State: isVisible()', () => {
   it('should return true if the element is visible', async () => {
     await page.goto('http://the-internet.herokuapp.com/dynamic_loading/1');
 
-    const isVisibleValue = await isVisible(page, '#start');
+    const isVisibleValue = await isVisible(page as never, '#start');
     expect(isVisibleValue).toBeTruthy();
   });
 
   it('should return false if the element has display=none', async () => {
     await page.goto('http://the-internet.herokuapp.com/dynamic_loading/1');
 
-    const isVisibleValue = await isVisible(page, '#finish');
+    const isVisibleValue = await isVisible(page as never, '#finish');
     expect(isVisibleValue).toBeFalsy();
   });
 
   it('should return false if the element bounding box === null', async () => {
     await page.goto('http://the-internet.herokuapp.com/hovers');
 
-    const isVisibleValue = await isVisible(page, '[href="/users/1"]');
+    const isVisibleValue = await isVisible(page as never, '[href="/users/1"]');
     expect(isVisibleValue).toBeFalsy();
   });
 });

--- a/tests/element/wait/waitToBeInViewport.spec.ts
+++ b/tests/element/wait/waitToBeInViewport.spec.ts
@@ -1,4 +1,4 @@
-import { waitToBeInViewport } from '../../../src/element/waits/waitToBeInViewport';
+import { waitToBeInViewport } from '../../../src';
 
 describe('Element Wait: waitToBeInViewport()', () => {
   beforeAll(async () => {
@@ -8,7 +8,7 @@ describe('Element Wait: waitToBeInViewport()', () => {
   it('should not fail by timeout if the element is in the viewport', async () => {
     const headerSelector = 'h3';
 
-    await waitToBeInViewport(page, headerSelector);
+    await waitToBeInViewport(page as never, headerSelector);
     expect(true).toBeTruthy();
   });
 
@@ -17,7 +17,9 @@ describe('Element Wait: waitToBeInViewport()', () => {
     const tableSelector = '#large-table';
 
     try {
-      await waitToBeInViewport(page, tableSelector, { timeoutMs: 2000 });
+      await waitToBeInViewport(page as never, tableSelector, {
+        timeoutMs: 2000,
+      });
     } catch (e) {
       isTimeout = true;
     }

--- a/tests/element/wait/waitToBeNotVisible.spec.ts
+++ b/tests/element/wait/waitToBeNotVisible.spec.ts
@@ -1,6 +1,4 @@
-import { waitToBeNotVisible } from '../../../src/element/waits/waitToBeNotVisible';
-import { isVisible } from '../../../src/element/states/isVisible';
-import { click } from '../../../src/element/actions/click';
+import { waitToBeNotVisible, isVisible, click } from '../../../src';
 
 describe('Element Wait: waitToBeNotVisible()', () => {
   beforeAll(async () => {
@@ -11,25 +9,13 @@ describe('Element Wait: waitToBeNotVisible()', () => {
     const loaderSelector = '#loading';
     const startButtonSelector = '#start button';
 
-    let startButtonStatus = await isVisible(page, startButtonSelector);
+    let startButtonStatus = await isVisible(page as never, startButtonSelector);
     expect(startButtonStatus).toBeTruthy();
 
-    await click(page, startButtonSelector);
-    await waitToBeNotVisible(page, loaderSelector);
+    await click(page as never, startButtonSelector);
+    await waitToBeNotVisible(page as never, loaderSelector);
 
-    startButtonStatus = await isVisible(page, startButtonSelector);
+    startButtonStatus = await isVisible(page as never, startButtonSelector);
     expect(startButtonStatus).toBeFalsy();
-  });
-
-  it('should not throw an exception if the element is not present', async () => {
-    const notPresentSelector = 'some-selector';
-    let exception = null;
-
-    try {
-      await waitToBeNotVisible(page, notPresentSelector, { timeoutMs: 1000 });
-    } catch (e) {
-      exception = e;
-    }
-    expect(exception).toBeNull();
   });
 });

--- a/tests/element/wait/waitToBeVisible.spec.ts
+++ b/tests/element/wait/waitToBeVisible.spec.ts
@@ -1,6 +1,4 @@
-import { waitToBeVisible } from '../../../src/element/waits/waitToBeVisible';
-import { isVisible } from '../../../src/element/states/isVisible';
-import { click } from '../../../src/element/actions/click';
+import { waitToBeVisible, isVisible, click } from '../../../src';
 
 describe('Element Wait: waitToBeVisible()', () => {
   beforeAll(async () => {
@@ -11,13 +9,13 @@ describe('Element Wait: waitToBeVisible()', () => {
     const finishSelector = '#finish';
     const startButtonSelector = '#start button';
 
-    let finishElementStatus = await isVisible(page, finishSelector);
+    let finishElementStatus = await isVisible(page as never, finishSelector);
     expect(finishElementStatus).toBeFalsy();
 
-    await click(page, startButtonSelector);
-    await waitToBeVisible(page, finishSelector);
+    await click(page as never, startButtonSelector);
+    await waitToBeVisible(page as never, finishSelector);
 
-    finishElementStatus = await isVisible(page, finishSelector);
+    finishElementStatus = await isVisible(page as never, finishSelector);
     expect(finishElementStatus).toBeTruthy();
   });
 });

--- a/tests/frame/search/getFrameByName.spec.ts
+++ b/tests/frame/search/getFrameByName.spec.ts
@@ -1,4 +1,4 @@
-import { getFrameByName } from '../../../src/frame/search/getFrameByName';
+import { getFrameByName } from '../../../src';
 
 describe('Frame Search: getFrameByName()', () => {
   const baseUrl = 'http://the-internet.herokuapp.com';
@@ -8,7 +8,7 @@ describe('Frame Search: getFrameByName()', () => {
   });
 
   it('should get frame by its name', async () => {
-    const frame = await getFrameByName(page, 'frame-right');
+    const frame = await getFrameByName(page as never, 'frame-right');
     expect(frame.url()).toBe(`${baseUrl}/frame_right`);
   });
 
@@ -16,7 +16,7 @@ describe('Frame Search: getFrameByName()', () => {
     let isTimeout = false;
 
     try {
-      await getFrameByName(page, 'frame-is-absent', {
+      await getFrameByName(page as never, 'frame-is-absent', {
         timeoutMs: 1000,
       });
     } catch (e) {

--- a/tests/frame/search/getFrameByUrl.spec.ts
+++ b/tests/frame/search/getFrameByUrl.spec.ts
@@ -1,4 +1,4 @@
-import { getFrameByUrl } from '../../../src/frame/search/getFrameByUrl';
+import { getFrameByUrl } from '../../../src';
 
 describe('Frame Search: getFrameByUrl()', () => {
   const baseUrl = 'http://the-internet.herokuapp.com';
@@ -8,12 +8,16 @@ describe('Frame Search: getFrameByUrl()', () => {
   });
 
   it('should get frame by part of its URL', async () => {
-    const frame = await getFrameByUrl(page, 'frame_middle');
+    const frame = await getFrameByUrl(page as never, 'frame_middle');
     expect(frame.name()).toBe('frame-middle');
   });
 
   it('should get frame by the whole URL value', async () => {
-    const frame = await getFrameByUrl(page, `${baseUrl}/frame_middle`, true);
+    const frame = await getFrameByUrl(
+      page as never,
+      `${baseUrl}/frame_middle`,
+      true,
+    );
     expect(frame.name()).toBe('frame-middle');
   });
 
@@ -21,7 +25,9 @@ describe('Frame Search: getFrameByUrl()', () => {
     let isTimeout = false;
 
     try {
-      await getFrameByUrl(page, `${baseUrl}`, true, { timeoutMs: 1000 });
+      await getFrameByUrl(page as never, `${baseUrl}`, true, {
+        timeoutMs: 1000,
+      });
     } catch (e) {
       isTimeout = true;
     }

--- a/tests/page/actions/switchToTab.spec.ts
+++ b/tests/page/actions/switchToTab.spec.ts
@@ -1,13 +1,11 @@
-import { click } from '../../../src/element/actions/click';
-import { getText } from '../../../src/element/actions/getText';
-import { switchToTab } from '../../../src/page/actions/switchToTab';
+import { click, getText, switchToTab } from '../../../src';
 
 describe('Page Actions: switchToTab()', () => {
   it('should switch to the new opened tab', async () => {
     await page.goto('http://the-internet.herokuapp.com/windows');
 
-    await click(page, '[href="/windows/new"]');
-    const newPage = await switchToTab(page, 'windows/new');
+    await click(page as never, '[href="/windows/new"]');
+    const newPage = await switchToTab(page as never, 'windows/new');
 
     const text = await getText(newPage, 'body');
     expect(text).toBe('New Window');

--- a/yarn.lock
+++ b/yarn.lock
@@ -712,9 +712,9 @@
     "@types/yargs-parser" "*"
 
 "@types/yauzl@^2.9.1":
-  version "2.9.1"
-  resolved "https://registry.yarnpkg.com/@types/yauzl/-/yauzl-2.9.1.tgz#d10f69f9f522eef3cf98e30afb684a1e1ec923af"
-  integrity sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==
+  version "2.10.0"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@types/yauzl/-/yauzl-2.10.0.tgz#b3248295276cf8c6f153ebe6a9aba0c988cb2599"
+  integrity sha1-sySClSds+MbxU+vmqaugyYjLJZk=
   dependencies:
     "@types/node" "*"
 
@@ -867,10 +867,12 @@ acorn@^8.1.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.2.4.tgz#caba24b08185c3b56e3168e97d15ed17f4d31fd0"
   integrity sha512-Ibt84YwBDDA890eDiDCEqcbwvHlBvzzDkU2cGBBDDI1QWT12jTiXIOn2CIw5KK4i6N5Z2HUxwYjzriDyqaqqZg==
 
-agent-base@5:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-5.1.1.tgz#e8fb3f242959db44d63be665db7a8e739537a32c"
-  integrity sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==
+agent-base@6:
+  version "6.0.2"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha1-Sf/1hXfP7j83F2/qtMIuAPhtf3c=
+  dependencies:
+    debug "4"
 
 aggregate-error@^3.0.0:
   version "3.1.0"
@@ -1140,8 +1142,8 @@ balanced-match@^1.0.0:
 
 base64-js@^1.3.1:
   version "1.5.1"
-  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
-  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha1-GxtEAWClv3rUC2UPCVljSBkDkwo=
 
 base@^0.11.1:
   version "0.11.2"
@@ -1165,8 +1167,8 @@ bcrypt-pbkdf@^1.0.0:
 
 bl@^4.0.3:
   version "4.1.0"
-  resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
-  integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
+  integrity sha1-RRU1JkGCvsL7vIOmKrmM8R2fezo=
   dependencies:
     buffer "^5.5.0"
     inherits "^2.0.4"
@@ -1235,7 +1237,7 @@ bser@2.1.1:
 
 buffer-crc32@~0.2.3:
   version "0.2.13"
-  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
   integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
 
 buffer-from@1.x, buffer-from@^1.0.0:
@@ -1245,8 +1247,8 @@ buffer-from@1.x, buffer-from@^1.0.0:
 
 buffer@^5.2.1, buffer@^5.5.0:
   version "5.7.1"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
-  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
+  integrity sha1-umLnwTEzBTWCGXFghRqPZI6Z7tA=
   dependencies:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
@@ -1330,8 +1332,8 @@ char-regex@^1.0.2:
 
 chownr@^1.1.1:
   version "1.1.4"
-  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
-  integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
+  integrity sha1-b8nXtC0ypYNZYzdmbn0ICE2izGs=
 
 ci-info@^2.0.0:
   version "2.0.0"
@@ -1536,6 +1538,13 @@ cosmiconfig@^7.0.0:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
+cross-fetch@3.1.5:
+  version "3.1.5"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
+  integrity sha1-4TifRNnnunZ5B/evhFR4eVKrU08=
+  dependencies:
+    node-fetch "2.6.7"
+
 cross-spawn@^6.0.0:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -1597,10 +1606,10 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, debug@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
-  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
+debug@4, debug@4.3.4:
+  version "4.3.4"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha1-Exn2V5NX8jONMzfSzdSRS7XcyGU=
   dependencies:
     ms "2.1.2"
 
@@ -1610,6 +1619,13 @@ debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
+
+debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, debug@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
+  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
+  dependencies:
+    ms "2.1.2"
 
 decamelize@^1.2.0:
   version "1.2.0"
@@ -1680,10 +1696,10 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
-devtools-protocol@0.0.818844:
-  version "0.0.818844"
-  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.818844.tgz#d1947278ec85b53e4c8ca598f607a28fa785ba9e"
-  integrity sha512-AD1hi7iVJ8OD0aMLQU5VK0XH9LDlA1+BcPIgrAxPfaibx2DbWucuyOhc4oyQCbnvDDO68nN6/LcKfqTP343Jjg==
+devtools-protocol@0.0.1001819:
+  version "0.0.1001819"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/devtools-protocol/-/devtools-protocol-0.0.1001819.tgz#0a98f44cefdb02cc684f3d5e6bd898a1690231d9"
+  integrity sha1-Cpj0TO/bAsxoTz1ea9iYoWkCMdk=
 
 diff-sequences@^26.6.2:
   version "26.6.2"
@@ -2107,10 +2123,10 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-extract-zip@^2.0.0:
+extract-zip@2.0.1:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-2.0.1.tgz#663dca56fe46df890d5f131ef4a06d22bb8ba13a"
-  integrity sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/extract-zip/-/extract-zip-2.0.1.tgz#663dca56fe46df890d5f131ef4a06d22bb8ba13a"
+  integrity sha1-Zj3KVv5G34kNXxMe9KBtIruLoTo=
   dependencies:
     debug "^4.1.1"
     get-stream "^5.1.0"
@@ -2176,7 +2192,7 @@ fb-watchman@^2.0.0:
 
 fd-slicer@~1.1.0:
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.1.0.tgz#25c7c89cb1f9077f8891bbe61d8f390eae256f1e"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/fd-slicer/-/fd-slicer-1.1.0.tgz#25c7c89cb1f9077f8891bbe61d8f390eae256f1e"
   integrity sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=
   dependencies:
     pend "~1.2.0"
@@ -2347,8 +2363,8 @@ fragment-cache@^0.2.1:
 
 fs-constants@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
-  integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
+  integrity sha1-a+Dem+mYzhavivwkSXue6bfM2a0=
 
 fs-exists-sync@^0.1.0:
   version "0.1.0"
@@ -2432,8 +2448,8 @@ get-stream@^4.0.0:
 
 get-stream@^5.0.0, get-stream@^5.1.0:
   version "5.2.0"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.2.0.tgz#4966a1795ee5ace65e706c4b7beb71257d6e22d3"
-  integrity sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/get-stream/-/get-stream-5.2.0.tgz#4966a1795ee5ace65e706c4b7beb71257d6e22d3"
+  integrity sha1-SWaheV7lrOZecGxLe+txJX1uItM=
   dependencies:
     pump "^3.0.0"
 
@@ -2667,12 +2683,12 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-https-proxy-agent@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz#702b71fb5520a132a66de1f67541d9e62154d82b"
-  integrity sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==
+https-proxy-agent@5.0.1:
+  version "5.0.1"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
+  integrity sha1-xZ7yJKBP6LdU89sAY6Jeow0ABdY=
   dependencies:
-    agent-base "5"
+    agent-base "6"
     debug "4"
 
 human-signals@^1.1.1:
@@ -2713,8 +2729,8 @@ iconv-lite@0.4.24:
 
 ieee754@^1.1.13:
   version "1.2.1"
-  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
-  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha1-jrehCmP/8l0VpXsAFYbRd9Gw01I=
 
 ignore@^4.0.6:
   version "4.0.6"
@@ -3935,8 +3951,8 @@ mixin-object@^2.0.1:
 
 mkdirp-classic@^0.5.2:
   version "0.5.3"
-  resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
-  integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
+  integrity sha1-+hDJEVzG2IZb4iG6R+6b7XhgERM=
 
 mkdirp@1.x:
   version "1.0.4"
@@ -3985,10 +4001,12 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-fetch@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
-  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+node-fetch@2.6.7:
+  version "2.6.7"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha1-JN6fuoJ+O0rkTciyAlajeRYAUq0=
+  dependencies:
+    whatwg-url "^5.0.0"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -4324,7 +4342,7 @@ path-type@^4.0.0:
 
 pend@~1.2.0:
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
   integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
 
 performance-now@^2.1.0:
@@ -4361,19 +4379,19 @@ pirates@^4.0.1:
   dependencies:
     node-modules-regexp "^1.0.0"
 
+pkg-dir@4.2.0, pkg-dir@^4.1.0, pkg-dir@^4.2.0:
+  version "4.2.0"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
+  integrity sha1-8JkTPfft5CLoHR2ESCcO6z5CYfM=
+  dependencies:
+    find-up "^4.0.0"
+
 pkg-dir@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-2.0.0.tgz#f6d5d1109e19d63edf428e0bd57e12777615334b"
   integrity sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=
   dependencies:
     find-up "^2.1.0"
-
-pkg-dir@^4.1.0, pkg-dir@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
-  integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
-  dependencies:
-    find-up "^4.0.0"
 
 please-upgrade-node@^3.2.0:
   version "3.2.0"
@@ -4424,10 +4442,10 @@ pretty-format@^26.0.0, pretty-format@^26.6.2:
     ansi-styles "^4.0.0"
     react-is "^17.0.1"
 
-progress@^2.0.0, progress@^2.0.1, progress@^2.0.3:
+progress@2.0.3, progress@^2.0.0, progress@^2.0.3:
   version "2.0.3"
-  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
-  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  integrity sha1-foz42PW48jnBvGi+tOt4Vn1XLvg=
 
 prompts@^2.0.1, prompts@^2.4.1:
   version "2.4.1"
@@ -4437,10 +4455,10 @@ prompts@^2.0.1, prompts@^2.4.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-proxy-from-env@^1.0.0:
+proxy-from-env@1.1.0:
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
-  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha1-4QLxbKNVQkhldV0sno6k8k1Yw+I=
 
 psl@^1.1.28, psl@^1.1.33:
   version "1.8.0"
@@ -4460,41 +4478,41 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-puppeteer-core@^5.5.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/puppeteer-core/-/puppeteer-core-5.5.0.tgz#dfb6266efe5a933cbf1a368d27025a6fd4f5a884"
-  integrity sha512-tlA+1n+ziW/Db03hVV+bAecDKse8ihFRXYiEypBe9IlLRvOCzYFG6qrCMBYK34HO/Q/Ecjc+tvkHRAfLVH+NgQ==
+puppeteer-core@14.3.0:
+  version "14.3.0"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/puppeteer-core/-/puppeteer-core-14.3.0.tgz#9594515e836c35be77db38d12fd6c9af43c97d03"
+  integrity sha1-lZRRXoNsNb532zjRL9bJr0PJfQM=
   dependencies:
-    debug "^4.1.0"
-    devtools-protocol "0.0.818844"
-    extract-zip "^2.0.0"
-    https-proxy-agent "^4.0.0"
-    node-fetch "^2.6.1"
-    pkg-dir "^4.2.0"
-    progress "^2.0.1"
-    proxy-from-env "^1.0.0"
-    rimraf "^3.0.2"
-    tar-fs "^2.0.0"
-    unbzip2-stream "^1.3.3"
-    ws "^7.2.3"
+    cross-fetch "3.1.5"
+    debug "4.3.4"
+    devtools-protocol "0.0.1001819"
+    extract-zip "2.0.1"
+    https-proxy-agent "5.0.1"
+    pkg-dir "4.2.0"
+    progress "2.0.3"
+    proxy-from-env "1.1.0"
+    rimraf "3.0.2"
+    tar-fs "2.1.1"
+    unbzip2-stream "1.4.3"
+    ws "8.7.0"
 
-puppeteer@^5.5.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-5.5.0.tgz#331a7edd212ca06b4a556156435f58cbae08af00"
-  integrity sha512-OM8ZvTXAhfgFA7wBIIGlPQzvyEETzDjeRa4mZRCRHxYL+GNH5WAuYUQdja3rpWZvkX/JKqmuVgbsxDNsDFjMEg==
+puppeteer@14.3.0:
+  version "14.3.0"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/puppeteer/-/puppeteer-14.3.0.tgz#0099cabf97767461aca02486313e84fcfc776af6"
+  integrity sha1-AJnKv5d2dGGsoCSGMT6E/Px3avY=
   dependencies:
-    debug "^4.1.0"
-    devtools-protocol "0.0.818844"
-    extract-zip "^2.0.0"
-    https-proxy-agent "^4.0.0"
-    node-fetch "^2.6.1"
-    pkg-dir "^4.2.0"
-    progress "^2.0.1"
-    proxy-from-env "^1.0.0"
-    rimraf "^3.0.2"
-    tar-fs "^2.0.0"
-    unbzip2-stream "^1.3.3"
-    ws "^7.2.3"
+    cross-fetch "3.1.5"
+    debug "4.3.4"
+    devtools-protocol "0.0.1001819"
+    extract-zip "2.0.1"
+    https-proxy-agent "5.0.1"
+    pkg-dir "4.2.0"
+    progress "2.0.3"
+    proxy-from-env "1.1.0"
+    rimraf "3.0.2"
+    tar-fs "2.1.1"
+    unbzip2-stream "1.4.3"
+    ws "8.7.0"
 
 qs@~6.5.2:
   version "6.5.2"
@@ -4557,8 +4575,8 @@ read-pkg@^5.2.0:
 
 readable-stream@^3.1.1, readable-stream@^3.4.0:
   version "3.6.0"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
-  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
+  integrity sha1-M3u9o63AcGvT4CRCaihtS0sskZg=
   dependencies:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
@@ -4712,10 +4730,10 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-rimraf@^3.0.0, rimraf@^3.0.2:
+rimraf@3.0.2, rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
-  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=
   dependencies:
     glob "^7.1.3"
 
@@ -4740,8 +4758,8 @@ rxjs@^6.6.3, rxjs@^6.6.7:
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
   version "5.2.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
-  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=
 
 safe-buffer@~5.1.1:
   version "5.1.2"
@@ -5117,8 +5135,8 @@ string.prototype.trimstart@^1.0.4:
 
 string_decoder@^1.1.1:
   version "1.3.0"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
-  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4=
   dependencies:
     safe-buffer "~5.2.0"
 
@@ -5214,10 +5232,10 @@ table@^6.0.4:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
 
-tar-fs@^2.0.0:
+tar-fs@2.1.1:
   version "2.1.1"
-  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.1.tgz#489a15ab85f1f0befabb370b7de4f9eb5cbe8784"
-  integrity sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/tar-fs/-/tar-fs-2.1.1.tgz#489a15ab85f1f0befabb370b7de4f9eb5cbe8784"
+  integrity sha1-SJoVq4Xx8L76uzcLfeT561y+h4Q=
   dependencies:
     chownr "^1.1.1"
     mkdirp-classic "^0.5.2"
@@ -5226,8 +5244,8 @@ tar-fs@^2.0.0:
 
 tar-stream@^2.1.4:
   version "2.2.0"
-  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287"
-  integrity sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287"
+  integrity sha1-rK2EwoQTawYNw/qmRHSqmuvXcoc=
   dependencies:
     bl "^4.0.3"
     end-of-stream "^1.4.1"
@@ -5332,6 +5350,11 @@ tr46@^2.0.2:
   integrity sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==
   dependencies:
     punycode "^2.1.1"
+
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
 
 tree-kill@^1.2.2:
   version "1.2.2"
@@ -5483,10 +5506,10 @@ unbox-primitive@^1.0.0:
     has-symbols "^1.0.2"
     which-boxed-primitive "^1.0.2"
 
-unbzip2-stream@^1.3.3:
+unbzip2-stream@1.4.3:
   version "1.4.3"
-  resolved "https://registry.yarnpkg.com/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz#b0da04c4371311df771cdc215e87f2130991ace7"
-  integrity sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz#b0da04c4371311df771cdc215e87f2130991ace7"
+  integrity sha1-sNoExDcTEd93HNwhXofyEwmRrOc=
   dependencies:
     buffer "^5.2.1"
     through "^2.3.8"
@@ -5538,7 +5561,7 @@ use@^3.1.0:
 
 util-deprecate@^1.0.1:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
 uuid@^3.3.2:
@@ -5628,6 +5651,11 @@ walker@^1.0.7, walker@~1.0.5:
   dependencies:
     makeerror "1.0.x"
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+
 webidl-conversions@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-5.0.0.tgz#ae59c8a00b121543a2acc65c0434f57b0fc11aff"
@@ -5649,6 +5677,14 @@ whatwg-mimetype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
   integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 whatwg-url@^8.0.0, whatwg-url@^8.5.0:
   version "8.5.0"
@@ -5737,7 +5773,12 @@ write-file-atomic@^3.0.0:
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
 
-ws@^7.2.3, ws@^7.4.4:
+ws@8.7.0:
+  version "8.7.0"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/ws/-/ws-8.7.0.tgz#eaf9d874b433aa00c0e0d8752532444875db3957"
+  integrity sha1-6vnYdLQzqgDA4Nh1JTJESHXbOVc=
+
+ws@^7.4.4:
   version "7.4.5"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.5.tgz#a484dd851e9beb6fdb420027e3885e8ce48986c1"
   integrity sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==
@@ -5804,7 +5845,7 @@ yargs@^15.4.1:
 
 yauzl@^2.10.0:
   version "2.10.0"
-  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
   integrity sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=
   dependencies:
     buffer-crc32 "~0.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -712,9 +712,9 @@
     "@types/yargs-parser" "*"
 
 "@types/yauzl@^2.9.1":
-  version "2.10.0"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@types/yauzl/-/yauzl-2.10.0.tgz#b3248295276cf8c6f153ebe6a9aba0c988cb2599"
-  integrity sha1-sySClSds+MbxU+vmqaugyYjLJZk=
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/@types/yauzl/-/yauzl-2.9.1.tgz#d10f69f9f522eef3cf98e30afb684a1e1ec923af"
+  integrity sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==
   dependencies:
     "@types/node" "*"
 
@@ -869,8 +869,8 @@ acorn@^8.1.0:
 
 agent-base@6:
   version "6.0.2"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
-  integrity sha1-Sf/1hXfP7j83F2/qtMIuAPhtf3c=
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
   dependencies:
     debug "4"
 
@@ -1142,8 +1142,8 @@ balanced-match@^1.0.0:
 
 base64-js@^1.3.1:
   version "1.5.1"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
-  integrity sha1-GxtEAWClv3rUC2UPCVljSBkDkwo=
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
 base@^0.11.1:
   version "0.11.2"
@@ -1167,8 +1167,8 @@ bcrypt-pbkdf@^1.0.0:
 
 bl@^4.0.3:
   version "4.1.0"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
-  integrity sha1-RRU1JkGCvsL7vIOmKrmM8R2fezo=
+  resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
+  integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
   dependencies:
     buffer "^5.5.0"
     inherits "^2.0.4"
@@ -1237,7 +1237,7 @@ bser@2.1.1:
 
 buffer-crc32@~0.2.3:
   version "0.2.13"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
+  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
   integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
 
 buffer-from@1.x, buffer-from@^1.0.0:
@@ -1247,8 +1247,8 @@ buffer-from@1.x, buffer-from@^1.0.0:
 
 buffer@^5.2.1, buffer@^5.5.0:
   version "5.7.1"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
-  integrity sha1-umLnwTEzBTWCGXFghRqPZI6Z7tA=
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
+  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
   dependencies:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
@@ -1332,8 +1332,8 @@ char-regex@^1.0.2:
 
 chownr@^1.1.1:
   version "1.1.4"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
-  integrity sha1-b8nXtC0ypYNZYzdmbn0ICE2izGs=
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
+  integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
 
 ci-info@^2.0.0:
   version "2.0.0"
@@ -1540,8 +1540,8 @@ cosmiconfig@^7.0.0:
 
 cross-fetch@3.1.5:
   version "3.1.5"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
-  integrity sha1-4TifRNnnunZ5B/evhFR4eVKrU08=
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
+  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
   dependencies:
     node-fetch "2.6.7"
 
@@ -1606,10 +1606,17 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-debug@4, debug@4.3.4:
+debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, debug@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
+  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
+  dependencies:
+    ms "2.1.2"
+
+debug@4.3.4:
   version "4.3.4"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
-  integrity sha1-Exn2V5NX8jONMzfSzdSRS7XcyGU=
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
 
@@ -1619,13 +1626,6 @@ debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
-
-debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, debug@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
-  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
-  dependencies:
-    ms "2.1.2"
 
 decamelize@^1.2.0:
   version "1.2.0"
@@ -1698,8 +1698,8 @@ detect-newline@^3.0.0:
 
 devtools-protocol@0.0.1001819:
   version "0.0.1001819"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/devtools-protocol/-/devtools-protocol-0.0.1001819.tgz#0a98f44cefdb02cc684f3d5e6bd898a1690231d9"
-  integrity sha1-Cpj0TO/bAsxoTz1ea9iYoWkCMdk=
+  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.1001819.tgz#0a98f44cefdb02cc684f3d5e6bd898a1690231d9"
+  integrity sha512-G6OsIFnv/rDyxSqBa2lDLR6thp9oJioLsb2Gl+LbQlyoA9/OBAkrTU9jiCcQ8Pnh7z4d6slDiLaogR5hzgJLmQ==
 
 diff-sequences@^26.6.2:
   version "26.6.2"
@@ -2125,8 +2125,8 @@ extglob@^2.0.4:
 
 extract-zip@2.0.1:
   version "2.0.1"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/extract-zip/-/extract-zip-2.0.1.tgz#663dca56fe46df890d5f131ef4a06d22bb8ba13a"
-  integrity sha1-Zj3KVv5G34kNXxMe9KBtIruLoTo=
+  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-2.0.1.tgz#663dca56fe46df890d5f131ef4a06d22bb8ba13a"
+  integrity sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==
   dependencies:
     debug "^4.1.1"
     get-stream "^5.1.0"
@@ -2192,7 +2192,7 @@ fb-watchman@^2.0.0:
 
 fd-slicer@~1.1.0:
   version "1.1.0"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/fd-slicer/-/fd-slicer-1.1.0.tgz#25c7c89cb1f9077f8891bbe61d8f390eae256f1e"
+  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.1.0.tgz#25c7c89cb1f9077f8891bbe61d8f390eae256f1e"
   integrity sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=
   dependencies:
     pend "~1.2.0"
@@ -2363,8 +2363,8 @@ fragment-cache@^0.2.1:
 
 fs-constants@^1.0.0:
   version "1.0.0"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
-  integrity sha1-a+Dem+mYzhavivwkSXue6bfM2a0=
+  resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
+  integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
 
 fs-exists-sync@^0.1.0:
   version "0.1.0"
@@ -2448,8 +2448,8 @@ get-stream@^4.0.0:
 
 get-stream@^5.0.0, get-stream@^5.1.0:
   version "5.2.0"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/get-stream/-/get-stream-5.2.0.tgz#4966a1795ee5ace65e706c4b7beb71257d6e22d3"
-  integrity sha1-SWaheV7lrOZecGxLe+txJX1uItM=
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.2.0.tgz#4966a1795ee5ace65e706c4b7beb71257d6e22d3"
+  integrity sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==
   dependencies:
     pump "^3.0.0"
 
@@ -2685,8 +2685,8 @@ http-signature@~1.2.0:
 
 https-proxy-agent@5.0.1:
   version "5.0.1"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
-  integrity sha1-xZ7yJKBP6LdU89sAY6Jeow0ABdY=
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
+  integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
   dependencies:
     agent-base "6"
     debug "4"
@@ -2729,8 +2729,8 @@ iconv-lite@0.4.24:
 
 ieee754@^1.1.13:
   version "1.2.1"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
-  integrity sha1-jrehCmP/8l0VpXsAFYbRd9Gw01I=
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
 ignore@^4.0.6:
   version "4.0.6"
@@ -3951,8 +3951,8 @@ mixin-object@^2.0.1:
 
 mkdirp-classic@^0.5.2:
   version "0.5.3"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
-  integrity sha1-+hDJEVzG2IZb4iG6R+6b7XhgERM=
+  resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
+  integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
 
 mkdirp@1.x:
   version "1.0.4"
@@ -4003,8 +4003,8 @@ nice-try@^1.0.4:
 
 node-fetch@2.6.7:
   version "2.6.7"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
-  integrity sha1-JN6fuoJ+O0rkTciyAlajeRYAUq0=
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
   dependencies:
     whatwg-url "^5.0.0"
 
@@ -4342,7 +4342,7 @@ path-type@^4.0.0:
 
 pend@~1.2.0:
   version "1.2.0"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
+  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
   integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
 
 performance-now@^2.1.0:
@@ -4381,8 +4381,8 @@ pirates@^4.0.1:
 
 pkg-dir@4.2.0, pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   version "4.2.0"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
-  integrity sha1-8JkTPfft5CLoHR2ESCcO6z5CYfM=
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
+  integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
 
@@ -4444,8 +4444,8 @@ pretty-format@^26.0.0, pretty-format@^26.6.2:
 
 progress@2.0.3, progress@^2.0.0, progress@^2.0.3:
   version "2.0.3"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
-  integrity sha1-foz42PW48jnBvGi+tOt4Vn1XLvg=
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
 prompts@^2.0.1, prompts@^2.4.1:
   version "2.4.1"
@@ -4457,8 +4457,8 @@ prompts@^2.0.1, prompts@^2.4.1:
 
 proxy-from-env@1.1.0:
   version "1.1.0"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
-  integrity sha1-4QLxbKNVQkhldV0sno6k8k1Yw+I=
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 psl@^1.1.28, psl@^1.1.33:
   version "1.8.0"
@@ -4480,8 +4480,8 @@ punycode@^2.1.0, punycode@^2.1.1:
 
 puppeteer-core@14.3.0:
   version "14.3.0"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/puppeteer-core/-/puppeteer-core-14.3.0.tgz#9594515e836c35be77db38d12fd6c9af43c97d03"
-  integrity sha1-lZRRXoNsNb532zjRL9bJr0PJfQM=
+  resolved "https://registry.yarnpkg.com/puppeteer-core/-/puppeteer-core-14.3.0.tgz#9594515e836c35be77db38d12fd6c9af43c97d03"
+  integrity sha512-84Oj29z/snMkwg2mHnWavtKUXHLUuVSaCb232btYUXxj5EBLwuq5xSVeCmS1LLuGcPfYZ39yceAuj3voyyHotQ==
   dependencies:
     cross-fetch "3.1.5"
     debug "4.3.4"
@@ -4498,8 +4498,8 @@ puppeteer-core@14.3.0:
 
 puppeteer@14.3.0:
   version "14.3.0"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/puppeteer/-/puppeteer-14.3.0.tgz#0099cabf97767461aca02486313e84fcfc776af6"
-  integrity sha1-AJnKv5d2dGGsoCSGMT6E/Px3avY=
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-14.3.0.tgz#0099cabf97767461aca02486313e84fcfc776af6"
+  integrity sha512-pDtg1+vyw1UPIhUjh2/VW1HUdQnaZJHfMacrJciR3AVm+PBiqdCEcFeFb3UJ/CDEQlHOClm3/WFa7IjY25zIGg==
   dependencies:
     cross-fetch "3.1.5"
     debug "4.3.4"
@@ -4575,8 +4575,8 @@ read-pkg@^5.2.0:
 
 readable-stream@^3.1.1, readable-stream@^3.4.0:
   version "3.6.0"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
-  integrity sha1-M3u9o63AcGvT4CRCaihtS0sskZg=
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
+  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
   dependencies:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
@@ -4732,8 +4732,8 @@ reusify@^1.0.4:
 
 rimraf@3.0.2, rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
-  integrity sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 
@@ -4758,8 +4758,8 @@ rxjs@^6.6.3, rxjs@^6.6.7:
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
   version "5.2.1"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
-  integrity sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
 safe-buffer@~5.1.1:
   version "5.1.2"
@@ -5135,8 +5135,8 @@ string.prototype.trimstart@^1.0.4:
 
 string_decoder@^1.1.1:
   version "1.3.0"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
-  integrity sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4=
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
   dependencies:
     safe-buffer "~5.2.0"
 
@@ -5234,8 +5234,8 @@ table@^6.0.4:
 
 tar-fs@2.1.1:
   version "2.1.1"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/tar-fs/-/tar-fs-2.1.1.tgz#489a15ab85f1f0befabb370b7de4f9eb5cbe8784"
-  integrity sha1-SJoVq4Xx8L76uzcLfeT561y+h4Q=
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.1.tgz#489a15ab85f1f0befabb370b7de4f9eb5cbe8784"
+  integrity sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==
   dependencies:
     chownr "^1.1.1"
     mkdirp-classic "^0.5.2"
@@ -5244,8 +5244,8 @@ tar-fs@2.1.1:
 
 tar-stream@^2.1.4:
   version "2.2.0"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287"
-  integrity sha1-rK2EwoQTawYNw/qmRHSqmuvXcoc=
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287"
+  integrity sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==
   dependencies:
     bl "^4.0.3"
     end-of-stream "^1.4.1"
@@ -5353,8 +5353,8 @@ tr46@^2.0.2:
 
 tr46@~0.0.3:
   version "0.0.3"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
-  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
 tree-kill@^1.2.2:
   version "1.2.2"
@@ -5508,8 +5508,8 @@ unbox-primitive@^1.0.0:
 
 unbzip2-stream@1.4.3:
   version "1.4.3"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz#b0da04c4371311df771cdc215e87f2130991ace7"
-  integrity sha1-sNoExDcTEd93HNwhXofyEwmRrOc=
+  resolved "https://registry.yarnpkg.com/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz#b0da04c4371311df771cdc215e87f2130991ace7"
+  integrity sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==
   dependencies:
     buffer "^5.2.1"
     through "^2.3.8"
@@ -5561,7 +5561,7 @@ use@^3.1.0:
 
 util-deprecate@^1.0.1:
   version "1.0.2"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
 uuid@^3.3.2:
@@ -5653,8 +5653,8 @@ walker@^1.0.7, walker@~1.0.5:
 
 webidl-conversions@^3.0.0:
   version "3.0.1"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
-  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
 
 webidl-conversions@^5.0.0:
   version "5.0.0"
@@ -5680,8 +5680,8 @@ whatwg-mimetype@^2.3.0:
 
 whatwg-url@^5.0.0:
   version "5.0.0"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
-  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
   dependencies:
     tr46 "~0.0.3"
     webidl-conversions "^3.0.0"
@@ -5775,8 +5775,8 @@ write-file-atomic@^3.0.0:
 
 ws@8.7.0:
   version "8.7.0"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/ws/-/ws-8.7.0.tgz#eaf9d874b433aa00c0e0d8752532444875db3957"
-  integrity sha1-6vnYdLQzqgDA4Nh1JTJESHXbOVc=
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.7.0.tgz#eaf9d874b433aa00c0e0d8752532444875db3957"
+  integrity sha512-c2gsP0PRwcLFzUiA8Mkr37/MI7ilIlHQxaEAtd0uNMbVMoy8puJyafRlm0bV9MbGSabUPeLrRRaqIBcFcA2Pqg==
 
 ws@^7.4.4:
   version "7.4.5"
@@ -5845,7 +5845,7 @@ yargs@^15.4.1:
 
 yauzl@^2.10.0:
   version "2.10.0"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
   integrity sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=
   dependencies:
     buffer-crc32 "~0.2.3"


### PR DESCRIPTION
The tests gets their types from `puppeteer` and not `puppeteer-core` (because they need to open browser) and there is miss-match in types of `puppeteer` and `puppeteer-core` (at current version) so I convert the `page` in tests to be `never`