### PR TITLE
Fix isVisible method

### DIFF
--- a/src/element/states/isVisible.ts
+++ b/src/element/states/isVisible.ts
@@ -16,7 +16,7 @@ export async function isVisible(
   context: Page | Frame,
   selector: string,
 ): Promise<boolean> {
-  const element = await page.$(selector);
+  const element = await context.$(selector);
   if (element === null) {
     return false;
   }


### PR DESCRIPTION
isVisible method was returning `ReferenceError: page is not defined`  in line 19. This looks like a simple bug where it should take context instead of page